### PR TITLE
fix(client): use env variables for all http requests

### DIFF
--- a/client/src/context/auth.context.jsx
+++ b/client/src/context/auth.context.jsx
@@ -1,7 +1,10 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
 
-const API_URL = "http://localhost:5005";
+
+// Import the string from the .env with URL of the API/server - http://localhost:5005
+const API_URL = import.meta.env.VITE_API_URL;
+
 
 const AuthContext = React.createContext();
 

--- a/client/src/pages/LoginPage.jsx
+++ b/client/src/pages/LoginPage.jsx
@@ -3,7 +3,10 @@ import axios from "axios";
 import { Link, useNavigate } from "react-router-dom";
 import { AuthContext } from "../context/auth.context";
 
-const API_URL = "http://localhost:5005";
+
+// Import the string from the .env with URL of the API/server - http://localhost:5005
+const API_URL = import.meta.env.VITE_API_URL;
+
 
 function LoginPage() {
   const [email, setEmail] = useState("");

--- a/client/src/pages/SignupPage.jsx
+++ b/client/src/pages/SignupPage.jsx
@@ -2,7 +2,9 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import axios from "axios";
 
-const API_URL = "http://localhost:5005";
+
+// Import the string from the .env with URL of the API/server - http://localhost:5005
+const API_URL = import.meta.env.VITE_API_URL;
 
 
 function SignupPage() {


### PR DESCRIPTION
In the React app, some of the files and components had the api url hardcoded.

This PR fixes that issue (all requests now use the existing environment variable `VITE_API_URL`).

